### PR TITLE
delete some vertical layout cruft so mobile renderings don't jump as …

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -111,6 +111,18 @@ main p#main-label {
   padding-top: 0;
 }
 
+main #word-to-guess {
+  background-color: #eee;
+  border-radius: 0.2em;
+  border: solid 1px teal;
+  color: black;
+  font-family: sans-serif;
+  letter-spacing: 0.25em;
+  margin-left: 1em;
+  padding: 0 0.5em;
+  text-align: center;
+}
+
 main p#main-content {
   color: gray;
   font-size: 0.9em;

--- a/assets/js/model.js
+++ b/assets/js/model.js
@@ -67,7 +67,7 @@ WordStop.prototype.lexicon = new Lexicon();
 WordStop.prototype.playState = "playing"; // "playing" | "won" | "lost"
 
 WordStop.prototype.getHintLetter = function() {
-    var results = this.currentGuess.indexOf("-");
+    var results = this.currentGuess.indexOf("_");
     if (results !== -1) {
         results = this.currentWord[results];
     }
@@ -94,7 +94,7 @@ WordStop.prototype.reset = function() {
     this.currentWord = this.lexicon.getWord();
     if (this.currentWord) {
         for (let i = 0; i <  this.currentWord.length; i++) {
-            this.currentGuess += "-";
+            this.currentGuess += "_";
         }
         return true;
     } else {

--- a/index.html
+++ b/index.html
@@ -43,10 +43,9 @@
 
     <main>
       <div class="container" id="main-container">
-        <p class="row" id="main-label">Play</p>
-        <hr />
-        <p>Guess the word: <span id="word-to-guess"></span></p>
-        <p></p>
+        <p class="row" id="main-label">
+          Guess the word: <span id="word-to-guess"></span>
+        </p>
         <form class="guessed-letter-form" id="guessed-letter-form">
           <!-- <label for="guessed-letter-input">Pick a letter ...</label> -->
           <input


### PR DESCRIPTION
On mobile, we need to pay attention to the pop-up keyboard widget that
can affect layout geometries.  It's better to minimize vertical space usage
so start by deleting the 'Play' label.

While we're at it, add some pleasing border and background to the guess-word
span.