### PR TITLE
app hardending: fix nuisance resets and focus loss conditions

### DIFF
--- a/assets/js/controller.js
+++ b/assets/js/controller.js
@@ -203,6 +203,7 @@ Controller.prototype.takeTurn = function(userGuess) {
             this.syncShowLoser(statusText);
             break;
     }
+    this.setFocus();
 }
 
 Controller.prototype.syncShowWinner = function(str) {
@@ -216,7 +217,20 @@ Controller.prototype.syncShowWinner = function(str) {
 Controller.prototype.getResetCallback = function() {
     var that = this;
     function callback() {
-        that.reset();
+
+        // NB: I'm seeing conditions in test whereby keyboard
+        // events seem to get buffered up between rounds of
+        // play causing multiple calls to reset, resulting in
+        // multiple new words to guess in rapdid succession.
+        // Here we enforce a single call to reset on win/loss 
+        // boundaries.
+        //
+        // TODO: Research ways to empty the event queue at the
+        //       end of a game to avoid possible spill-over events.
+
+        if (that.gameObj.playState == "won" || that.gameObj.playState == "lost") {
+            that.reset();
+        }
     }
     return callback;
 }


### PR DESCRIPTION
During extended testing, I'm seeing two conditions:

1. The input text form loses focus and players are unable
   to type in new letters.  Clicking on the form doesn't
   restore focus for some reason.  I need to understand this
   better.

   For now, I'm adding a call to setFocus at the end of each takeTurn
   invocation.  (The word around was to select a menu item which
   would then call setFocus).

2. I'm seeing multiple 'nuisance' calls to the controller reset
   method which I've wrappered in a debouncing timeout
   from within a keyboard event handler.  I'm guessing this isn't
   good form since it ties up event processing during the timeout.

   I need to research better ways to accomplish a pause between
   rounds, but for now, I'm simply adding some guard logic around
   the controller reset method:

Controller.prototype.getResetCallback = function() {
    var that = this;
    function callback() {

	// guard logic to debounce calls to reset

        if (that.gameObj.playState == "won" || that.gameObj.playState == "lost") {
            that.reset();
        }
    }
    return callback;
}