### PR TITLE
trim down 'Guesses left' to 'Guesses'

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
           Letters used: <span id="letters-used-text"></span>
         </p>
         <p id="guesses-left">
-          Guesses left: <span id="guesses-left-num"></span>
+          Guesses: <span id="guesses-left-num"></span>
         </p>
 
         <div


### PR DESCRIPTION
Now that letters used and guesses left occupy the same line,
letters used can actually wrap, causing alignment issues with the
stop-sign rendering.