### PR TITLE
give letters used a tad more space to prevent wrap

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -163,7 +163,7 @@ main #guessed-letter-form {
 
 main #letters-used {
   float: left;
-  width: 50%;
+  width: 55%;
 }
 
 @media screen and (max-width: 640px) {


### PR DESCRIPTION
Still getting some wrapping on mobile on 8 bad guesses.  Extending width of field to 55% of available width.