### PR TITLE
be more responsive when letters guessed wrap

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -183,7 +183,7 @@ main #stop-text {
 
 @media screen and (max-width: 640px) {
   main div#stop-sign {
-    clear: right;
+    clear: both;
   }
 }
 


### PR DESCRIPTION
Clear left and right floats when rendering stop-sign, otherwise half the stop-sign tries to float right next to the wrapped guessed letters. :-/