### PR TITLE
soft keyboard still popping up on hint

### DIFF
--- a/assets/js/controller.js
+++ b/assets/js/controller.js
@@ -205,21 +205,15 @@ Controller.prototype.getHintMenuEventCallback = function() {
             let ch = that.gameObj.getHintLetter();
             if (ch !== -1) {
                 // alert("Hint: Try '" + ch + "'");
+                that.setBlur(); // prevent soft keyboard from popping up on hint
                 swal({
                     text: ch,
                     buttons: false,
                     timer: 1500,
-                }).then(function() {
-                    that.setFocus();
                 });
             } else {
                 // alert("Hint: No more hints left. :-/");
-                swal({
-                    title: "No hints left!",
-                    text: ":-/",
-                    buttons: false,
-                    timer: 3000,
-                });
+                swal("No hints left!");
             }
         }
         that.setFocus();
@@ -341,6 +335,11 @@ Controller.prototype.resetGuessedLetterForm = function() {
 Controller.prototype.setFocus = function() {
     let id = document.getElementById("guessed-letter-input");
     id.focus();
+}
+
+Controller.prototype.setBlur = function() {
+    let id = document.getElementById("guessed-letter-input");
+    id.blur();
 }
 
 Controller.prototype.showStatusText = function(text, bgColor = "#999") {


### PR DESCRIPTION
Testing on mobile currently takes me through a deployment workflow.
Still wrestling with soft keyboard popups on mobile when sweetalert
gives a hint.

Here I blur focus on the input element before calling sweetalert.