### PR TITLE
rollback to vanilla alerts on 'Hints' to avoid soft keyboard popups

### DIFF
--- a/assets/js/controller.js
+++ b/assets/js/controller.js
@@ -204,21 +204,21 @@ Controller.prototype.getHintMenuEventCallback = function() {
         if (that.gameObj.getPlayState() == "playing") {
             let ch = that.gameObj.getHintLetter();
             if (ch !== -1) {
-                // alert("Hint: Try '" + ch + "'");
-                that.setBlur(); // prevent soft keyboard from popping up.
-                swal({
-                    text: ch,
-                    buttons: false,
-                    timer: 1500
-                }).then(function() {
-                    that.setFocus();
-                });
+                alert("Hint: Try '" + ch + "'");
+                // that.setBlur(); // prevent soft keyboard from popping up.
+                // swal({
+                //     text: ch,
+                //     buttons: false,
+                //     timer: 1500
+                // }).then(function() {
+                //     that.setFocus();
+                // });
             } else {
-                // alert("Hint: No more hints left. :-/");
-                swal("No hints left!");
+                alert("Hint: No more hints left. :-/");
+                // swal("No hints left!");
             }
         }
-        // that.setFocus();
+        that.setFocus();
     }
     return menuCallback;
 }


### PR DESCRIPTION
Otherwise, the hint is actually occluded by the popup keyboard.
Not sure how to horse-whisper sweetalerts on mobile to prevent this
at this stage.